### PR TITLE
feat: import transactions from CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,17 @@ Login demo: `admin@demo.local` / `admin123`.
 
 User tambahan untuk uji undangan: `member@demo.local` / `member123`.
 Setelah login sebagai member, kunjungi `/invite/demo-token` untuk menerima undangan ke Demo Org.
+
+## Import CSV
+
+File CSV harus memiliki kolom `Date`, `Description`, dan `Amount`. Nilai `Amount` negatif akan diimport sebagai pengeluaran, positif sebagai pemasukan. Tanggal boleh dalam format `YYYY-MM-DD` atau `DD/MM/YYYY`.
+
+Contoh:
+
+```
+Date,Description,Amount
+2025-08-01,GOJEK-FOOD,-45000
+2025-08-01,Gaji Agustus,15000000
+```
+
+Gunakan fitur Rule dengan properti `contains` untuk mengkategorikan transaksi otomatis pada import berikutnya.

--- a/app/[locale]/transactions/page.tsx
+++ b/app/[locale]/transactions/page.tsx
@@ -1,6 +1,81 @@
-import { useTranslations } from 'next-intl';
+import UploadCSV from '@/components/transactions/UploadCSV';
+import TransactionsTable from '@/components/transactions/TransactionsTable';
+import { requireUser } from '@/lib/auth/requireUser';
+import { requireOrg } from '@/lib/auth/requireOrg';
+import { listTransactions } from '@/app/transactions/actions';
+import { prisma } from '@/lib/prisma';
+import { getTranslations } from 'next-intl/server';
 
-export default function TransactionsPage() {
-  const t = useTranslations();
-  return <div className="p-4">{t('Transactions')}</div>;
+export default async function TransactionsPage({
+  searchParams,
+}: {
+  searchParams: { q?: string; categoryId?: string; sort?: string; page?: string };
+}) {
+  const t = await getTranslations();
+  await requireUser();
+  const orgId = await requireOrg();
+  const page = parseInt(searchParams.page || '1', 10);
+  const { txs, total } = await listTransactions({
+    orgId,
+    q: searchParams.q,
+    categoryId: searchParams.categoryId,
+    sort: searchParams.sort,
+    page,
+    pageSize: 20,
+  });
+  const categories = (await prisma.category.findMany({ where: { orgId } })) as {
+    id: string;
+    name: string;
+    kind: string;
+  }[];
+  const totalPages = Math.ceil(total / 20);
+  return (
+    <div>
+      <UploadCSV />
+      <form method="get" className="mb-4 flex gap-2">
+        <input
+          type="text"
+          name="q"
+          defaultValue={searchParams.q || ''}
+          placeholder={t('Search')}
+          className="border p-1"
+        />
+        <select
+          name="categoryId"
+          defaultValue={searchParams.categoryId || ''}
+          className="border p-1"
+        >
+          <option value="">{t('All Categories')}</option>
+          {categories.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name}
+            </option>
+          ))}
+        </select>
+        <select name="sort" defaultValue={searchParams.sort || 'dateDesc'} className="border p-1">
+          <option value="dateDesc">{t('Date')} ↓</option>
+          <option value="dateAsc">{t('Date')} ↑</option>
+          <option value="amountDesc">{t('Amount')} ↓</option>
+          <option value="amountAsc">{t('Amount')} ↑</option>
+        </select>
+        <button type="submit" className="border px-2">
+          {t('Filter')}
+        </button>
+      </form>
+      <TransactionsTable transactions={txs} categories={categories} />
+      {totalPages > 1 && (
+        <div className="mt-2 flex gap-2">
+          {Array.from({ length: totalPages }, (_, i) => {
+            const p = i + 1;
+            const sp = new URLSearchParams({ ...searchParams, page: String(p) });
+            return (
+              <a key={p} href={`?${sp.toString()}`} className={p === page ? 'font-bold' : ''}>
+                {p}
+              </a>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
 }

--- a/app/transactions/actions.ts
+++ b/app/transactions/actions.ts
@@ -1,0 +1,146 @@
+'use server';
+
+import { requireUser } from '@/lib/auth/requireUser';
+import { requireOrg } from '@/lib/auth/requireOrg';
+import { prisma } from '@/lib/prisma';
+import { parseTransactions } from '@/lib/csv/parseTransactions';
+import { matchRule, RuleLike } from '@/lib/ruleMatcher';
+
+interface ImportData {
+  orgId: string;
+  occurredAt: Date;
+  amount: number;
+  description?: string;
+  categoryId: string | null;
+  source: string;
+}
+
+export async function importTransactions(formData: FormData) {
+  await requireUser();
+  const orgId = await requireOrg();
+  const file = formData.get('file') as File | null;
+  if (!file) {
+    return { insertedCount: 0, errorCount: 1, errors: [{ line: 0, error: 'No file' }] };
+  }
+  const text = await file.text();
+  const { rows, errors } = await parseTransactions(text);
+
+  const rules = (await prisma.rule.findMany({
+    where: { orgId, active: true },
+  })) as RuleLike[];
+
+  const seen = new Set<string>();
+  const data: ImportData[] = [];
+
+  for (const r of rows) {
+    const key = `${r.occurredAt.getTime()}|${r.amountCents}|${r.description ?? ''}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const categoryId = matchRule(r.description || '', rules);
+    const amount = r.isIncome ? r.amountCents : -r.amountCents;
+    data.push({
+      orgId,
+      occurredAt: r.occurredAt,
+      amount,
+      description: r.description,
+      categoryId,
+      source: 'csv',
+    });
+  }
+
+  let insertedCount = 0;
+  if (data.length > 0) {
+    const result = await prisma.transaction.createMany({ data });
+    insertedCount = result.count;
+  }
+  return {
+    insertedCount,
+    errorCount: errors.length,
+    errors,
+    previewTopMatches: data
+      .slice(0, 5)
+      .map((d) => ({ description: d.description, categoryId: d.categoryId })),
+  };
+}
+
+export async function updateTransactionCategory({
+  id,
+  categoryId,
+}: {
+  id: string;
+  categoryId: string | null;
+}) {
+  await requireUser();
+  const orgId = await requireOrg();
+  const res = await prisma.transaction.updateMany({
+    where: { id, orgId },
+    data: { categoryId },
+  });
+  if (res.count === 0) throw new Error('Not found');
+}
+
+export async function deleteTransaction({ id }: { id: string }) {
+  await requireUser();
+  const orgId = await requireOrg();
+  await prisma.transaction.deleteMany({ where: { id, orgId } });
+}
+
+export async function listTransactions({
+  orgId,
+  q,
+  categoryId,
+  sort = 'dateDesc',
+  page = 1,
+  pageSize = 20,
+}: {
+  orgId: string;
+  q?: string;
+  categoryId?: string;
+  sort?: string;
+  page?: number;
+  pageSize?: number;
+}) {
+  const where: {
+    orgId: string;
+    description?: { contains: string; mode: 'insensitive' };
+    categoryId?: string;
+  } = { orgId };
+  if (q) where.description = { contains: q, mode: 'insensitive' };
+  if (categoryId) where.categoryId = categoryId;
+  const orderBy =
+    sort === 'dateAsc'
+      ? { occurredAt: 'asc' }
+      : sort === 'amountAsc'
+        ? { amount: 'asc' }
+        : sort === 'amountDesc'
+          ? { amount: 'desc' }
+          : { occurredAt: 'desc' };
+
+  const txs = await prisma.transaction.findMany({
+    where,
+    orderBy,
+    skip: (page - 1) * pageSize,
+    take: pageSize,
+    include: { category: true },
+  });
+  const total = await prisma.transaction.count({ where });
+  return { txs, total };
+}
+
+export async function countByCategory({
+  orgId,
+  month,
+  year,
+}: {
+  orgId: string;
+  month: number;
+  year: number;
+}) {
+  const start = new Date(year, month - 1, 1);
+  const end = new Date(year, month, 1);
+  return prisma.transaction.groupBy({
+    by: ['categoryId'],
+    where: { orgId, occurredAt: { gte: start, lt: end } },
+    _sum: { amount: true },
+  });
+}

--- a/components/CategorySelect.tsx
+++ b/components/CategorySelect.tsx
@@ -1,0 +1,40 @@
+'use client';
+import { useTransition } from 'react';
+import { updateTransactionCategory } from '@/app/transactions/actions';
+
+interface Option {
+  id: string;
+  name: string;
+  kind: string;
+}
+
+export default function CategorySelect({
+  txId,
+  value,
+  options,
+}: {
+  txId: string;
+  value: string | null;
+  options: Option[];
+}) {
+  const [isPending, startTransition] = useTransition();
+
+  return (
+    <select
+      className="border p-1"
+      defaultValue={value || ''}
+      onChange={(e) => {
+        const categoryId = e.target.value || null;
+        startTransition(() => updateTransactionCategory({ id: txId, categoryId }));
+      }}
+      disabled={isPending}
+    >
+      <option value="">-</option>
+      {options.map((o) => (
+        <option key={o.id} value={o.id}>
+          {o.name}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/components/transactions/TransactionsTable.tsx
+++ b/components/transactions/TransactionsTable.tsx
@@ -1,0 +1,67 @@
+'use client';
+import { useTransition } from 'react';
+import { deleteTransaction } from '@/app/transactions/actions';
+import CategorySelect from '../CategorySelect';
+import { formatDate } from '@/lib/date';
+import { formatCurrencyIDR } from '@/lib/formatCurrencyIDR';
+import { useTranslations } from 'next-intl';
+
+interface Tx {
+  id: string;
+  occurredAt: string | Date;
+  description?: string | null;
+  categoryId?: string | null;
+  amount: number;
+}
+
+interface Category {
+  id: string;
+  name: string;
+  kind: string;
+}
+
+export default function TransactionsTable({
+  transactions,
+  categories,
+}: {
+  transactions: Tx[];
+  categories: Category[];
+}) {
+  const t = useTranslations();
+  const [isPending, startTransition] = useTransition();
+
+  return (
+    <table className="w-full text-sm border">
+      <thead>
+        <tr>
+          <th className="border p-1">{t('Date')}</th>
+          <th className="border p-1">{t('Description')}</th>
+          <th className="border p-1">{t('Category')}</th>
+          <th className="border p-1">{t('Amount')}</th>
+          <th className="border p-1">{t('Actions')}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {transactions.map((tx) => (
+          <tr key={tx.id} className="border-t">
+            <td className="p-1">{formatDate(tx.occurredAt, 'yyyy-MM-dd')}</td>
+            <td className="p-1">{tx.description}</td>
+            <td className="p-1">
+              <CategorySelect txId={tx.id} value={tx.categoryId || null} options={categories} />
+            </td>
+            <td className="p-1 text-right">{formatCurrencyIDR(tx.amount / 100)}</td>
+            <td className="p-1 text-center">
+              <button
+                className="text-red-600"
+                disabled={isPending}
+                onClick={() => startTransition(() => deleteTransaction({ id: tx.id }))}
+              >
+                {t('Delete')}
+              </button>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/components/transactions/UploadCSV.tsx
+++ b/components/transactions/UploadCSV.tsx
@@ -1,0 +1,56 @@
+'use client';
+import { useState, useTransition } from 'react';
+import { importTransactions } from '@/app/transactions/actions';
+import { useTranslations } from 'next-intl';
+
+interface ImportError {
+  line: number;
+  error: string;
+}
+
+interface ImportResult {
+  insertedCount: number;
+  errorCount: number;
+  errors?: ImportError[];
+}
+
+export default function UploadCSV() {
+  const t = useTranslations();
+  const [result, setResult] = useState<ImportResult | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  async function action(formData: FormData) {
+    startTransition(async () => {
+      const res = await importTransactions(formData);
+      setResult(res);
+    });
+  }
+
+  return (
+    <form action={action} className="mb-4 rounded border p-4" encType="multipart/form-data">
+      <input type="file" name="file" accept=".csv,text/csv" className="mb-2" />
+      <button type="submit" disabled={isPending} className="border px-2 py-1">
+        {t('Upload CSV')}
+      </button>
+      {result && (
+        <div className="mt-2 text-sm">
+          <div>
+            {t('Inserted')}: {result.insertedCount} | {t('Errors')}: {result.errorCount}
+          </div>
+          {result.errors?.length && (
+            <details className="mt-1">
+              <summary>{t('Row Errors')}</summary>
+              <ul className="ml-4 list-disc">
+                {result.errors.map((e) => (
+                  <li key={e.line}>
+                    {e.line}: {e.error}
+                  </li>
+                ))}
+              </ul>
+            </details>
+          )}
+        </div>
+      )}
+    </form>
+  );
+}

--- a/lib/amount.ts
+++ b/lib/amount.ts
@@ -1,0 +1,5 @@
+export function toCents(amount: number | string): number {
+  const num = typeof amount === 'number' ? amount : parseFloat(amount.replace(/,/g, ''));
+  if (isNaN(num)) return 0;
+  return Math.round(num * 100);
+}

--- a/lib/csv/parseTransactions.test.ts
+++ b/lib/csv/parseTransactions.test.ts
@@ -1,0 +1,19 @@
+import { expect, it } from 'vitest';
+import { parseTransactions } from './parseTransactions';
+
+const sample = `Date,Description,Amount\n2025-08-01,GOJEK-FOOD,-45000\n02/08/2025,PLN Prepaid,-200000\n`;
+
+it('parses dates and amounts correctly', async () => {
+  const { rows, errors } = await parseTransactions(sample);
+  expect(errors.length).toBe(0);
+  expect(rows.length).toBe(2);
+  expect(rows[0].amountCents).toBe(4500000);
+  expect(rows[0].isIncome).toBe(false);
+  expect(rows[1].amountCents).toBe(20000000);
+});
+
+it('collects errors for invalid rows', async () => {
+  const { rows, errors } = await parseTransactions(`Date,Description,Amount\n2025-08-01,,abc\n`);
+  expect(rows.length).toBe(0);
+  expect(errors.length).toBe(1);
+});

--- a/lib/csv/parseTransactions.ts
+++ b/lib/csv/parseTransactions.ts
@@ -1,0 +1,71 @@
+import { parse } from 'csv-parse';
+import { Readable } from 'stream';
+import { parse as parseDate, isValid } from 'date-fns';
+import { zonedTimeToUtc } from 'date-fns-tz';
+import { toCents } from '../amount';
+
+export interface ParsedRow {
+  occurredAt: Date;
+  description?: string;
+  amountCents: number;
+  isIncome: boolean;
+}
+
+export interface ParseResult {
+  rows: ParsedRow[];
+  errors: { line: number; error: string }[];
+}
+
+const TZ = 'Asia/Jakarta';
+
+function parseOccurredAt(value: string): Date | null {
+  const formats = ['yyyy-MM-dd', 'dd/MM/yyyy'];
+  for (const fmt of formats) {
+    const d = parseDate(value, fmt, new Date());
+    if (isValid(d)) {
+      return zonedTimeToUtc(d, TZ);
+    }
+  }
+  return null;
+}
+
+export async function parseTransactions(csv: string): Promise<ParseResult> {
+  const rows: ParsedRow[] = [];
+  const errors: { line: number; error: string }[] = [];
+  const parser = parse({
+    columns: (header) => header.map((h) => h.trim().toLowerCase()),
+    skip_empty_lines: true,
+    trim: true,
+  });
+  Readable.from(csv).pipe(parser);
+
+  let line = 1;
+  for await (const record of parser) {
+    line += 1;
+    const dateStr = record['date'];
+    const amountStr = record['amount'];
+    const description = record['description']?.trim();
+
+    if (!dateStr || !amountStr) {
+      errors.push({ line, error: 'Missing required fields' });
+      continue;
+    }
+
+    const occurredAt = parseOccurredAt(dateStr);
+    if (!occurredAt) {
+      errors.push({ line, error: 'Invalid date' });
+      continue;
+    }
+
+    const amountNum = parseFloat(amountStr.replace(/,/g, ''));
+    if (isNaN(amountNum)) {
+      errors.push({ line, error: 'Invalid amount' });
+      continue;
+    }
+    const isIncome = amountNum >= 0;
+    const amountCents = Math.abs(toCents(amountNum));
+    rows.push({ occurredAt, description, amountCents, isIncome });
+  }
+
+  return { rows, errors };
+}

--- a/lib/ruleMatcher.test.ts
+++ b/lib/ruleMatcher.test.ts
@@ -1,0 +1,22 @@
+import { it, expect } from 'vitest';
+import { matchRule, RuleLike } from './ruleMatcher';
+
+const rules: RuleLike[] = [
+  { contains: 'gojek', categoryId: 'A', createdAt: new Date('2024-01-01') },
+  { contains: 'gojek-food', categoryId: 'B', createdAt: new Date('2024-01-02') },
+  { contains: 'shop', categoryId: 'C', createdAt: new Date('2024-01-03') },
+];
+
+it('matches case-insensitive and longest pattern', () => {
+  const cat = matchRule('GOJEK-FOOD order', rules);
+  expect(cat).toBe('B');
+});
+
+it('prefers first rule when tie', () => {
+  const tieRules: RuleLike[] = [
+    { contains: 'abc', categoryId: '1' },
+    { contains: 'abc', categoryId: '2' },
+  ];
+  const cat = matchRule('xxabcxx', tieRules);
+  expect(cat).toBe('1');
+});

--- a/lib/ruleMatcher.ts
+++ b/lib/ruleMatcher.ts
@@ -1,0 +1,29 @@
+export interface RuleLike {
+  contains: string;
+  categoryId: string;
+  createdAt?: Date;
+}
+
+export function matchRule(description: string, rules: RuleLike[]): string | null {
+  const desc = description.toLowerCase();
+  const matches = rules
+    .map((r, index) => ({
+      rule: r,
+      index,
+      contains: r.contains.toLowerCase().trim(),
+    }))
+    .filter((r) => desc.includes(r.contains));
+
+  if (matches.length === 0) return null;
+
+  matches.sort((a, b) => {
+    const lenDiff = b.contains.length - a.contains.length;
+    if (lenDiff !== 0) return lenDiff;
+    const aTime = a.rule.createdAt ? a.rule.createdAt.getTime() : 0;
+    const bTime = b.rule.createdAt ? b.rule.createdAt.getTime() : 0;
+    if (bTime !== aTime) return bTime - aTime;
+    return a.index - b.index;
+  });
+
+  return matches[0].rule.categoryId;
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -9,5 +9,18 @@
   "Save": "Save",
   "Cancel": "Cancel",
   "Register": "Register",
-  "Organization": "Organization"
+  "Organization": "Organization",
+  "Upload CSV": "Upload CSV",
+  "Inserted": "Inserted",
+  "Errors": "Errors",
+  "Row Errors": "Row Errors",
+  "Date": "Date",
+  "Description": "Description",
+  "Category": "Category",
+  "Amount": "Amount",
+  "Actions": "Actions",
+  "Delete": "Delete",
+  "Search": "Search",
+  "All Categories": "All Categories",
+  "Filter": "Filter"
 }

--- a/messages/id.json
+++ b/messages/id.json
@@ -9,5 +9,18 @@
   "Save": "Simpan",
   "Cancel": "Batal",
   "Register": "Daftar",
-  "Organization": "Organisasi"
+  "Organization": "Organisasi",
+  "Upload CSV": "Unggah CSV",
+  "Inserted": "Berhasil",
+  "Errors": "Gagal",
+  "Row Errors": "Kesalahan Baris",
+  "Date": "Tanggal",
+  "Description": "Deskripsi",
+  "Category": "Kategori",
+  "Amount": "Jumlah",
+  "Actions": "Aksi",
+  "Delete": "Hapus",
+  "Search": "Cari",
+  "All Categories": "Semua Kategori",
+  "Filter": "Saring"
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "dependencies": {
     "@prisma/client": "^5.14.0",
     "bcryptjs": "^2.4.3",
-    "date-fns": "^3.6.0",
+    "csv-parse": "^6.1.0",
+    "date-fns": "^2.30.0",
     "date-fns-tz": "^2.0.0",
     "next": "^14.0.0",
     "next-auth": "^4.24.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,12 +14,15 @@ importers:
       bcryptjs:
         specifier: ^2.4.3
         version: 2.4.3
+      csv-parse:
+        specifier: ^6.1.0
+        version: 6.1.0
       date-fns:
-        specifier: ^3.6.0
-        version: 3.6.0
+        specifier: ^2.30.0
+        version: 2.30.0
       date-fns-tz:
         specifier: ^2.0.0
-        version: 2.0.1(date-fns@3.6.0)
+        version: 2.0.1(date-fns@2.30.0)
       next:
         specifier: ^14.0.0
         version: 14.2.31(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1033,6 +1036,9 @@ packages:
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
+  csv-parse@6.1.0:
+    resolution: {integrity: sha512-CEE+jwpgLn+MmtCpVcPtiCZpVtB6Z2OKPTr34pycYYoL7sxdOkXDdQ4lRiw6ioC0q6BLqhc6cKweCVvral8yhw==}
+
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
@@ -1053,8 +1059,9 @@ packages:
     peerDependencies:
       date-fns: 2.x
 
-  date-fns@3.6.0:
-    resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
+  date-fns@2.30.0:
+    resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
+    engines: {node: '>=0.11'}
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -3499,6 +3506,8 @@ snapshots:
 
   csstype@3.1.3: {}
 
+  csv-parse@6.1.0: {}
+
   damerau-levenshtein@1.0.8: {}
 
   data-view-buffer@1.0.2:
@@ -3519,11 +3528,13 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
-  date-fns-tz@2.0.1(date-fns@3.6.0):
+  date-fns-tz@2.0.1(date-fns@2.30.0):
     dependencies:
-      date-fns: 3.6.0
+      date-fns: 2.30.0
 
-  date-fns@3.6.0: {}
+  date-fns@2.30.0:
+    dependencies:
+      '@babel/runtime': 7.28.3
 
   debug@3.2.7:
     dependencies:


### PR DESCRIPTION
## Summary
- add CSV parser and rule matcher for auto-categorizing transactions
- allow uploading CSV files, listing transactions with filters, and inline category edits
- document CSV import format and add translations

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build` *(fails: Failed to collect page data for /[locale]/budgets)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689f4863909c8327ae3ae52de912d038