### PR TITLE
feat: add AI coach scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,24 @@ Halaman `/goals` digunakan untuk membuat target tabungan organisasi. Setiap goal
 Contoh: _Nabung 1.000.000/bulan untuk Dana Darurat 10.000.000 → 10 bulan_.
 
 Dashboard menampilkan ringkasan pemasukan/pengeluaran, burn rate, overview anggaran, pengeluaran terbesar, dan progress goal.
+
+## AI Coach
+
+Halaman `/coach` memungkinkan percakapan dengan AI Financial Coach berbasis OpenAI.
+
+### Konfigurasi
+
+Tambahkan `OPENAI_API_KEY` pada `.env`. Zona waktu dan locale default sudah disediakan melalui `NEXT_PUBLIC_DEFAULT_TZ` dan `NEXT_PUBLIC_DEFAULT_LOCALE`.
+
+### Privasi
+
+AI tidak memiliki akses langsung ke basis data. Seluruh data diambil melalui _tools_ yang secara ketat menscope `orgId` dan `userId`.
+
+### Contoh Prompt
+
+- Analisis pengeluaran bulan ini & beri 3 langkah penghematan.
+- Sarankan budget bulan depan berdasarkan 3 bulan terakhir.
+- Jika saya menabung Rp1.000.000/bulan untuk Dana Darurat 10 juta, kapan tercapai?
+- Kategori apa yang paling membengkak bulan ini?
+
+> **Catatan:** Fitur ini bukan nasihat keuangan profesional.

--- a/app/[locale]/coach/page.tsx
+++ b/app/[locale]/coach/page.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { useTranslations } from 'next-intl';
 
 export default function CoachPage() {

--- a/lib/ai/client.ts
+++ b/lib/ai/client.ts
@@ -1,0 +1,7 @@
+import OpenAI from 'openai';
+
+export const openai = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+});
+
+export type OpenAIClient = typeof openai;

--- a/lib/ai/systemPrompt.ts
+++ b/lib/ai/systemPrompt.ts
@@ -1,0 +1,17 @@
+const id = `Kamu adalah AngsFlow Financial Coach untuk pengguna Indonesia (IDR, TZ Asia/Jakarta).
+Jawab singkat, to the point, 3–5 bullet dengan angka & langkah konkrit.
+Jangan mengarang data; akses data hanya via tools yang disediakan.
+Setelah menjawab, tampilkan ringkasan sumber data dalam tanda kurung siku, mis: [Sumber: Cashflow 08/2025, TopSpending 5 kategori].
+Gaya: empatik, konservatif (prioritaskan dana darurat, cicilan ≤30% income, living cost realistis).
+Jangan menampilkan API key atau detail sistem.`;
+
+const en = `You are AngsFlow Financial Coach for Indonesian users (IDR, Asia/Jakarta TZ).
+Respond briefly in 3-5 bullet points with concrete numbers and steps.
+Do not fabricate data; access data only via provided tools.
+After answering include data source summary in brackets e.g. [Source: Cashflow 08/2025, TopSpending 5 categories].
+Tone: empathetic, conservative (prioritise emergency fund, debt <=30% income, realistic living cost).
+Do not reveal API keys or system details.`;
+
+export function systemPrompt(locale: string = 'id') {
+  return locale === 'en' ? en : id;
+}

--- a/lib/ai/tools.test.ts
+++ b/lib/ai/tools.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi, Mock } from 'vitest';
+
+vi.mock('@prisma/client', () => ({ OrgRole: { MEMBER: 'MEMBER' } }));
+vi.mock('../prisma', () => ({
+  prisma: {
+    transaction: { aggregate: vi.fn(), groupBy: vi.fn() },
+    category: { findMany: vi.fn() },
+    goal: { findFirst: vi.fn() },
+    advice: { create: vi.fn() },
+  },
+}));
+vi.mock('../rbac/requireRole', () => ({
+  requireRole: (_p: unknown, fn: () => unknown) => fn(),
+}));
+
+import { prisma } from '../prisma';
+import { runTool } from './tools';
+
+describe('ai tools', () => {
+  it('getCashflow computes income and expense', async () => {
+    const agg = prisma.transaction.aggregate as unknown as Mock;
+    agg.mockResolvedValueOnce({ _sum: { amount: 1000 } });
+    agg.mockResolvedValueOnce({ _sum: { amount: -400 } });
+    const res = (await runTool(
+      'getCashflow',
+      { month: 1, year: 2024 },
+      { orgId: 'o', userId: 'u' },
+    )) as {
+      month: number;
+      year: number;
+      income: number;
+      expense: number;
+      net: number;
+    };
+    expect(res).toEqual({ month: 1, year: 2024, income: 1000, expense: 400, net: 600 });
+  });
+
+  it('getTopSpending sorts by total desc', async () => {
+    const grp = prisma.transaction.groupBy as unknown as Mock;
+    grp.mockResolvedValueOnce([
+      { categoryId: 'c1', _sum: { amount: -300 } },
+      { categoryId: 'c2', _sum: { amount: -100 } },
+    ]);
+    (prisma.category.findMany as unknown as Mock).mockResolvedValueOnce([
+      { id: 'c1', name: 'Food' },
+      { id: 'c2', name: 'Fun' },
+    ]);
+    const res = (await runTool(
+      'getTopSpending',
+      { month: 1, year: 2024, limit: 5 },
+      { orgId: 'o', userId: 'u' },
+    )) as { categoryId: string; categoryName: string; total: number }[];
+    expect(res[0]).toEqual({ categoryId: 'c1', categoryName: 'Food', total: 300 });
+    expect(res[1]).toEqual({ categoryId: 'c2', categoryName: 'Fun', total: 100 });
+  });
+
+  it('projectGoal handles statuses', async () => {
+    const gf = prisma.goal.findFirst as unknown as Mock;
+    // achieved
+    gf.mockResolvedValueOnce({ id: 'g1', targetAmt: 1000, savedAmt: 1000 });
+    let res = (await runTool(
+      'projectGoal',
+      { goalId: 'g1', monthlySave: 100 },
+      { orgId: 'o', userId: 'u' },
+    )) as { status: string; monthsNeeded?: number | null };
+    expect(res.status).toBe('achieved');
+    // unreachable
+    gf.mockResolvedValueOnce({ id: 'g1', targetAmt: 1000, savedAmt: 200 });
+    res = (await runTool(
+      'projectGoal',
+      { goalId: 'g1', monthlySave: 0 },
+      { orgId: 'o', userId: 'u' },
+    )) as { status: string; monthsNeeded?: number | null };
+    expect(res.status).toBe('unreachable');
+    // estimated
+    gf.mockResolvedValueOnce({ id: 'g1', targetAmt: 1000, savedAmt: 200 });
+    res = (await runTool(
+      'projectGoal',
+      { goalId: 'g1', monthlySave: 200 },
+      { orgId: 'o', userId: 'u' },
+    )) as { status: string; monthsNeeded?: number | null };
+    expect(res.status).toBe('estimated');
+    expect(res.monthsNeeded).toBe(4);
+  });
+
+  it('suggestBudget averages last 3 months', async () => {
+    const grp = prisma.transaction.groupBy as unknown as Mock;
+    grp.mockResolvedValueOnce([{ categoryId: 'c1', _sum: { amount: -900 } }]);
+    (prisma.category.findMany as unknown as Mock).mockResolvedValueOnce([
+      { id: 'c1', name: 'Food' },
+    ]);
+    const res = (await runTool(
+      'suggestBudget',
+      { month: 4, year: 2024 },
+      { orgId: 'o', userId: 'u' },
+    )) as { categoryId: string; suggestedLimit: number }[];
+    expect(res[0].suggestedLimit).toBe(300);
+  });
+});

--- a/lib/ai/tools.ts
+++ b/lib/ai/tools.ts
@@ -1,0 +1,273 @@
+import { OrgRole } from '@prisma/client';
+import { z } from 'zod';
+import { prisma } from '../prisma';
+import { requireRole } from '../rbac/requireRole';
+import { addMonths, endOfMonth } from 'date-fns';
+import { utcToZonedTime } from 'date-fns-tz';
+
+export class ToolError extends Error {}
+
+const cashflowSchema = z.object({
+  month: z.number().int().min(1).max(12),
+  year: z.number().int(),
+});
+
+async function getCashflow(
+  { month, year, orgId }: { month: number; year: number; orgId: string },
+  userId: string,
+) {
+  return requireRole({ userId, orgId, roles: [OrgRole.MEMBER] }, async () => {
+    const start = new Date(year, month - 1, 1);
+    const end = new Date(year, month, 1);
+    const [inc, exp] = await Promise.all([
+      prisma.transaction.aggregate({
+        _sum: { amount: true },
+        where: {
+          orgId,
+          occurredAt: { gte: start, lt: end },
+          amount: { gt: 0 },
+        },
+      }),
+      prisma.transaction.aggregate({
+        _sum: { amount: true },
+        where: {
+          orgId,
+          occurredAt: { gte: start, lt: end },
+          amount: { lt: 0 },
+        },
+      }),
+    ]);
+    const income = inc._sum.amount ?? 0;
+    const expense = Math.abs(exp._sum.amount ?? 0);
+    return { month, year, income, expense, net: income - expense };
+  });
+}
+
+const topSpendingSchema = z.object({
+  month: z.number().int().min(1).max(12),
+  year: z.number().int(),
+  limit: z.number().int().min(1).max(10).default(5),
+});
+
+async function getTopSpending(
+  { month, year, limit, orgId }: { month: number; year: number; limit: number; orgId: string },
+  userId: string,
+) {
+  return requireRole({ userId, orgId, roles: [OrgRole.MEMBER] }, async () => {
+    const start = new Date(year, month - 1, 1);
+    const end = new Date(year, month, 1);
+    const grouped = (await prisma.transaction.groupBy({
+      by: ['categoryId'],
+      _sum: { amount: true },
+      where: {
+        orgId,
+        occurredAt: { gte: start, lt: end },
+        amount: { lt: 0 },
+        categoryId: { not: null },
+      },
+      orderBy: { _sum: { amount: 'asc' } },
+      take: limit,
+    })) as { categoryId: string | null; _sum: { amount: number | null } }[];
+    const ids = grouped.map((g) => g.categoryId!).filter(Boolean) as string[];
+    const cats = (await prisma.category.findMany({
+      where: { id: { in: ids } },
+      select: { id: true, name: true },
+    })) as { id: string; name: string }[];
+    const nameMap = Object.fromEntries(cats.map((c) => [c.id, c.name] as const));
+    return grouped.map((g) => ({
+      categoryId: g.categoryId!,
+      categoryName: nameMap[g.categoryId!] || 'Unknown',
+      total: Math.abs(g._sum.amount ?? 0),
+    }));
+  });
+}
+
+const suggestBudgetSchema = z.object({
+  month: z.number().int().min(1).max(12),
+  year: z.number().int(),
+});
+
+async function suggestBudget(
+  { month, year, orgId }: { month: number; year: number; orgId: string },
+  userId: string,
+) {
+  return requireRole({ userId, orgId, roles: [OrgRole.MEMBER] }, async () => {
+    const start = addMonths(new Date(year, month - 1, 1), -3);
+    const end = new Date(year, month - 1, 1);
+    const grouped = (await prisma.transaction.groupBy({
+      by: ['categoryId'],
+      _sum: { amount: true },
+      where: {
+        orgId,
+        occurredAt: { gte: start, lt: end },
+        amount: { lt: 0 },
+        category: { kind: 'VARIABLE' },
+      },
+    })) as { categoryId: string | null; _sum: { amount: number | null } }[];
+    const ids = grouped.map((g) => g.categoryId!).filter(Boolean) as string[];
+    const cats = (await prisma.category.findMany({
+      where: { id: { in: ids } },
+      select: { id: true, name: true },
+    })) as { id: string; name: string }[];
+    const nameMap = Object.fromEntries(cats.map((c) => [c.id, c.name] as const));
+    return grouped.map((g) => {
+      const avg = Math.abs(g._sum.amount ?? 0) / 3;
+      const suggestedLimit = Math.max(Math.round(avg), 0);
+      return {
+        categoryId: g.categoryId!,
+        categoryName: nameMap[g.categoryId!] || 'Unknown',
+        suggestedLimit,
+        rationale: `Rerata 3 bulan: ${suggestedLimit}`,
+      };
+    });
+  });
+}
+
+const projectGoalSchema = z.object({
+  goalId: z.string(),
+  monthlySave: z.number().int().min(0),
+});
+
+async function projectGoal(
+  { goalId, monthlySave, orgId }: { goalId: string; monthlySave: number; orgId: string },
+  userId: string,
+) {
+  return requireRole({ userId, orgId, roles: [OrgRole.MEMBER] }, async () => {
+    const goal = await prisma.goal.findFirst({ where: { id: goalId, orgId } });
+    if (!goal) throw new ToolError('Goal not found');
+    const remaining = goal.targetAmt - goal.savedAmt;
+    if (remaining <= 0) {
+      return {
+        goalId,
+        monthsNeeded: 0,
+        etaDateISO: new Date().toISOString(),
+        status: 'achieved' as const,
+      };
+    }
+    if (monthlySave <= 0) {
+      return {
+        goalId,
+        monthsNeeded: null,
+        etaDateISO: null,
+        status: 'unreachable' as const,
+      };
+    }
+    const monthsNeeded = Math.ceil(remaining / monthlySave);
+    const eta = endOfMonth(addMonths(new Date(), monthsNeeded));
+    const zoned = utcToZonedTime(eta, 'Asia/Jakarta');
+    return { goalId, monthsNeeded, etaDateISO: zoned.toISOString(), status: 'estimated' as const };
+  });
+}
+
+const createAdviceSchema = z.object({
+  title: z.string(),
+  message: z.string(),
+  meta: z.any().optional(),
+});
+
+async function createAdvice(
+  {
+    title,
+    message,
+    meta,
+    orgId,
+  }: { title: string; message: string; meta?: unknown; orgId: string },
+  userId: string,
+) {
+  return requireRole({ userId, orgId, roles: [OrgRole.MEMBER] }, async () => {
+    const advice = await prisma.advice.create({
+      data: { title, message, metaJson: meta ?? null, orgId, userId },
+      select: { id: true },
+    });
+    return { adviceId: advice.id };
+  });
+}
+
+export const toolConfigs = {
+  getCashflow: {
+    schema: cashflowSchema,
+    parameters: {
+      type: 'object',
+      properties: {
+        month: { type: 'number' },
+        year: { type: 'number' },
+      },
+      required: ['month', 'year'],
+    },
+    exec: getCashflow,
+  },
+  getTopSpending: {
+    schema: topSpendingSchema,
+    parameters: {
+      type: 'object',
+      properties: {
+        month: { type: 'number' },
+        year: { type: 'number' },
+        limit: { type: 'number', default: 5 },
+      },
+      required: ['month', 'year'],
+    },
+    exec: getTopSpending,
+  },
+  suggestBudget: {
+    schema: suggestBudgetSchema,
+    parameters: {
+      type: 'object',
+      properties: {
+        month: { type: 'number' },
+        year: { type: 'number' },
+      },
+      required: ['month', 'year'],
+    },
+    exec: suggestBudget,
+  },
+  projectGoal: {
+    schema: projectGoalSchema,
+    parameters: {
+      type: 'object',
+      properties: {
+        goalId: { type: 'string' },
+        monthlySave: { type: 'number' },
+      },
+      required: ['goalId', 'monthlySave'],
+    },
+    exec: projectGoal,
+  },
+  createAdvice: {
+    schema: createAdviceSchema,
+    parameters: {
+      type: 'object',
+      properties: {
+        title: { type: 'string' },
+        message: { type: 'string' },
+        meta: { type: 'object' },
+      },
+      required: ['title', 'message'],
+    },
+    exec: createAdvice,
+  },
+};
+
+export type ToolName = keyof typeof toolConfigs;
+
+export const aiToolDefinitions = Object.entries(toolConfigs).map(([name, t]) => ({
+  type: 'function',
+  function: { name, parameters: t.parameters },
+}));
+
+export async function runTool(name: string, args: unknown, ctx: { orgId: string; userId: string }) {
+  const conf = (toolConfigs as Record<string, unknown>)[name];
+  if (!conf || typeof conf !== 'object') throw new ToolError('Unknown tool');
+  const cfg = conf as {
+    schema: z.ZodTypeAny;
+    exec: (args: Record<string, unknown>, userId: string) => Promise<unknown>;
+  };
+  const input = cfg.schema.parse(args);
+  try {
+    return await cfg.exec({ ...input, orgId: ctx.orgId }, ctx.userId);
+  } catch (e: unknown) {
+    if (e instanceof ToolError) throw e;
+    if (e instanceof Error) throw new ToolError(e.message);
+    throw new ToolError('Tool error');
+  }
+}

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "next-auth": "^4.24.5",
     "next-intl": "^3.2.1",
     "next-themes": "^0.2.1",
+    "openai": "^5.12.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "zod": "^3.22.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       next-themes:
         specifier: ^0.2.1
         version: 0.2.1(next@14.2.31(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      openai:
+        specifier: ^5.12.2
+        version: 5.12.2(zod@3.25.76)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -1967,6 +1970,18 @@ packages:
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
+
+  openai@5.12.2:
+    resolution: {integrity: sha512-xqzHHQch5Tws5PcKR2xsZGX9xtch+JQFz5zb14dGqlshmmDAFBFEWmeIpf7wVqWV+w7Emj7jRgkNJakyKE0tYQ==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
 
   openid-client@5.7.1:
     resolution: {integrity: sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==}
@@ -4629,6 +4644,10 @@ snapshots:
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
+
+  openai@5.12.2(zod@3.25.76):
+    optionalDependencies:
+      zod: 3.25.76
 
   openid-client@5.7.1:
     dependencies:

--- a/prisma/migrations/20240519000000_add_chat_thread/migration.sql
+++ b/prisma/migrations/20240519000000_add_chat_thread/migration.sql
@@ -1,0 +1,25 @@
+CREATE TABLE "ChatThread" (
+  "id" TEXT NOT NULL,
+  "orgId" TEXT NOT NULL,
+  "userId" TEXT NOT NULL,
+  "title" TEXT,
+  "summary" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "ChatThread_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "ChatThread_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Organization"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT "ChatThread_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE TABLE "ChatMessage" (
+  "id" TEXT NOT NULL,
+  "threadId" TEXT NOT NULL,
+  "role" TEXT NOT NULL,
+  "content" TEXT NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "ChatMessage_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "ChatMessage_threadId_fkey" FOREIGN KEY ("threadId") REFERENCES "ChatThread"("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE INDEX "ChatThread_orgId_userId_createdAt_idx" ON "ChatThread"("orgId", "userId", "createdAt");
+CREATE INDEX "ChatMessage_threadId_createdAt_idx" ON "ChatMessage"("threadId", "createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -137,15 +137,39 @@ updatedAt DateTime @updatedAt
 }
 
 model Advice {
-id String @id @default(cuid())
-userId String
-user User @relation(fields: [userId], references: [id])
-orgId String
-org Organization @relation(fields: [orgId], references: [id])
-title String
-message String
-metaJson Json?
-createdAt DateTime @default(now())
+  id String @id @default(cuid())
+  userId String
+  user User @relation(fields: [userId], references: [id])
+  orgId String
+  org Organization @relation(fields: [orgId], references: [id])
+  title String
+  message String
+  metaJson Json?
+  createdAt DateTime @default(now())
+}
+
+model ChatThread {
+  id        String        @id @default(cuid())
+  orgId     String
+  userId    String
+  title     String?
+  messages  ChatMessage[]
+  summary   String?
+  createdAt DateTime      @default(now())
+  updatedAt DateTime      @updatedAt
+
+  @@index([orgId, userId, createdAt])
+}
+
+model ChatMessage {
+  id        String      @id @default(cuid())
+  threadId  String
+  thread    ChatThread  @relation(fields: [threadId], references: [id])
+  role      String
+  content   String
+  createdAt DateTime    @default(now())
+
+  @@index([threadId, createdAt])
 }
 
 enum GlobalRole { ADMIN USER }


### PR DESCRIPTION
## Summary
- add ChatThread and ChatMessage models for storing coach conversations
- introduce OpenAI client, system prompt, and server-side tool wrappers
- document AI Coach setup and prompts

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build` *(fails: Cannot find module '.prisma/client/default')*


------
https://chatgpt.com/codex/tasks/task_e_689f6e1d7ff88327b5cb2edd406d6aed