### PR TITLE
feat: reports hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,9 @@ AI tidak memiliki akses langsung ke basis data. Seluruh data diambil melalui _to
 - Kategori apa yang paling membengkak bulan ini?
 
 > **Catatan:** Fitur ini bukan nasihat keuangan profesional.
+
+## Reports & Hardening
+
+Halaman `/reports` menampilkan grafik arus kas 12 bulan terakhir dan pie pengeluaran per kategori bulan berjalan. Data diolah melalui helper pada `lib/analytics.ts` yang menscope `orgId` dan menggunakan zona waktu `Asia/Jakarta`.
+
+Autentikasi dan aksi chat dilindungi oleh util rate limit (`lib/rateLimit.ts`) dengan batas default 10 permintaan/10 menit untuk login dan 1 pesan/2 detik untuk coach. Middleware tenant memastikan semua operasi basis data terscope ke organisasi aktif.

--- a/app/[locale]/error.tsx
+++ b/app/[locale]/error.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useTranslations } from 'next-intl';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  const t = useTranslations();
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+  return (
+    <div className="p-4 space-y-4">
+      <p>{t('Sumber data tidak tersedia')}</p>
+      <button className="underline" onClick={() => reset()}>
+        {t('Coba lagi')}
+      </button>
+      <a className="underline" href="https://github.com/angsflow/angsflow/issues" target="_blank">
+        Report issue
+      </a>
+    </div>
+  );
+}

--- a/app/[locale]/reports/page.tsx
+++ b/app/[locale]/reports/page.tsx
@@ -1,0 +1,46 @@
+import { requireUser } from '@/lib/auth/requireUser';
+import { requireOrg } from '@/lib/auth/requireOrg';
+import { getMonthlySeries, getCategoryBreakdown, getAdviceRecent } from '@/lib/analytics';
+type Advice = { id: string; title: string };
+import CashflowChart from '@/components/reports/CashflowChart';
+import CategoryPie from '@/components/reports/CategoryPie';
+import { getTranslations } from 'next-intl/server';
+
+export default async function ReportsPage() {
+  const t = await getTranslations();
+  const user = await requireUser();
+  const orgId = await requireOrg();
+  const now = new Date();
+  const month = now.getMonth() + 1;
+  const year = now.getFullYear();
+  const [series, categories, advices]: [
+    Awaited<ReturnType<typeof getMonthlySeries>>,
+    Awaited<ReturnType<typeof getCategoryBreakdown>>,
+    Advice[],
+  ] = await Promise.all([
+    getMonthlySeries({ orgId }),
+    getCategoryBreakdown({ orgId, month, year }),
+    getAdviceRecent({ orgId, userId: user.id }),
+  ]);
+  return (
+    <div className="p-4 space-y-8">
+      <h1 className="text-xl">{t('Reports')}</h1>
+      <section className="space-y-2">
+        <h2 className="font-semibold">{t('Cashflow (12 bulan)')}</h2>
+        <CashflowChart data={series} />
+      </section>
+      <section className="space-y-2">
+        <h2 className="font-semibold">{t('Kategori Pengeluaran (Bulan Ini)')}</h2>
+        {categories.length > 0 ? <CategoryPie data={categories} /> : <p>{t('Tidak ada data')}</p>}
+      </section>
+      <section className="space-y-2">
+        <h2 className="font-semibold">{t('Rekomendasi Terbaru')}</h2>
+        <ul className="list-disc pl-4">
+          {advices.map((a) => (
+            <li key={a.id}>{a.title}</li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,7 +1,20 @@
 import NextAuth from 'next-auth';
 import { authOptions } from '@/lib/auth';
+import { limit } from '@/lib/rateLimit';
+import type { NextRequest } from 'next/server';
 
 const handler = NextAuth(authOptions);
 
-export { handler as GET, handler as POST };
+export async function POST(req: NextRequest, ctx: unknown) {
+  const ip = req.headers.get('x-forwarded-for') || req.ip || 'unknown';
+  try {
+    await limit({ key: `${ip}:auth`, limit: 10, windowMs: 10 * 60 * 1000 });
+  } catch (e) {
+    return new Response('Too many requests', { status: 429 });
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return handler(req, ctx as any);
+}
+
+export { handler as GET };
 export const runtime = 'nodejs';

--- a/app/coach/actions.ts
+++ b/app/coach/actions.ts
@@ -1,0 +1,14 @@
+'use server';
+
+import { requireUser } from '@/lib/auth/requireUser';
+import { limit } from '@/lib/rateLimit';
+
+export async function sendMessage({ message }: { message: string }) {
+  const user = await requireUser();
+  try {
+    await limit({ key: `${user.id}:coach`, limit: 1, windowMs: 2000 });
+  } catch {
+    throw new Response('Too many requests', { status: 429 });
+  }
+  return { reply: `Received: ${message}` };
+}

--- a/components/reports/CashflowChart.tsx
+++ b/components/reports/CashflowChart.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { AreaChart, Area, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+
+const monthFmt = new Intl.DateTimeFormat('id-ID', {
+  month: 'short',
+  year: '2-digit',
+});
+const currencyFmt = new Intl.NumberFormat('id-ID', {
+  style: 'currency',
+  currency: 'IDR',
+  notation: 'compact',
+});
+
+export default function CashflowChart({
+  data,
+}: {
+  data: { y: number; m: number; income: number; expense: number; net: number }[];
+}) {
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <AreaChart data={data}>
+        <XAxis dataKey={(d) => monthFmt.format(new Date(d.y, d.m - 1))} />
+        <YAxis tickFormatter={(v) => currencyFmt.format(v)} />
+        <Tooltip formatter={(v: number) => currencyFmt.format(v)} />
+        <Legend />
+        <Area type="monotone" dataKey="income" stroke="#4ade80" fill="#4ade80" />
+        <Area type="monotone" dataKey="expense" stroke="#f87171" fill="#f87171" />
+        <Area type="monotone" dataKey="net" stroke="#60a5fa" fill="#60a5fa" />
+      </AreaChart>
+    </ResponsiveContainer>
+  );
+}

--- a/components/reports/CategoryPie.tsx
+++ b/components/reports/CategoryPie.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+
+const COLORS = ['#60a5fa', '#f87171', '#fbbf24', '#4ade80', '#a78bfa'];
+const currencyFmt = new Intl.NumberFormat('id-ID', {
+  style: 'currency',
+  currency: 'IDR',
+  notation: 'compact',
+});
+
+export default function CategoryPie({
+  data,
+}: {
+  data: { categoryId: string; categoryName: string; total: number }[];
+}) {
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <PieChart>
+        <Pie
+          data={data}
+          dataKey="total"
+          nameKey="categoryName"
+          label={({ percent }) => `${(percent * 100).toFixed(0)}%`}
+        >
+          {data.map((entry, index) => (
+            <Cell key={entry.categoryId} fill={COLORS[index % COLORS.length]} />
+          ))}
+        </Pie>
+        <Tooltip formatter={(v: number) => currencyFmt.format(v)} />
+        <Legend />
+      </PieChart>
+    </ResponsiveContainer>
+  );
+}

--- a/lib/analytics.test.ts
+++ b/lib/analytics.test.ts
@@ -4,11 +4,24 @@ vi.mock('./prisma', () => ({
   prisma: {
     transaction: {
       aggregate: vi.fn(),
+      findMany: vi.fn(),
+      groupBy: vi.fn(),
+    },
+    category: {
+      findMany: vi.fn(),
+    },
+    advice: {
+      findMany: vi.fn(),
     },
   },
 }));
 import { prisma } from './prisma';
-import { getMonthlyCashflow, getBurnRate } from './analytics';
+import {
+  getMonthlyCashflow,
+  getBurnRate,
+  getMonthlySeries,
+  getCategoryBreakdown,
+} from './analytics';
 
 describe('analytics', () => {
   it('computes cashflow correctly', async () => {
@@ -22,5 +35,39 @@ describe('analytics', () => {
   it('burn rate', () => {
     const br = getBurnRate({ income: 1000, expense: 500 });
     expect(br).toBe(0.5);
+  });
+
+  it('monthly series returns fixed number of points and respects timezone', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-03-15T00:00:00Z'));
+    const find = prisma.transaction.findMany as Mock;
+    find.mockResolvedValueOnce([
+      { amount: 100, occurredAt: new Date('2024-02-29T17:00:00Z') }, // Mar 1 local
+      { amount: -50, occurredAt: new Date('2024-02-10T00:00:00Z') },
+    ]);
+    const res = await getMonthlySeries({ orgId: 'o', monthsBack: 2 });
+    vi.useRealTimers();
+    expect(res).toEqual([
+      { y: 2024, m: 2, income: 0, expense: 50, net: -50 },
+      { y: 2024, m: 3, income: 100, expense: 0, net: 100 },
+    ]);
+  });
+
+  it('category breakdown aggregates expenses and sorts', async () => {
+    const groupBy = prisma.transaction.groupBy as Mock;
+    groupBy.mockResolvedValueOnce([
+      { categoryId: 'c1', _sum: { amount: -300 } },
+      { categoryId: 'c2', _sum: { amount: -100 } },
+    ]);
+    const cat = prisma.category.findMany as Mock;
+    cat.mockResolvedValueOnce([
+      { id: 'c1', name: 'Food' },
+      { id: 'c2', name: 'Travel' },
+    ]);
+    const res = await getCategoryBreakdown({ orgId: 'o', month: 1, year: 2024 });
+    expect(res).toEqual([
+      { categoryId: 'c1', categoryName: 'Food', total: 300 },
+      { categoryId: 'c2', categoryName: 'Travel', total: 100 },
+    ]);
   });
 });

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { prisma } from './prisma';
+import { startOfMonth, subMonths, addMonths } from 'date-fns';
+import { utcToZonedTime, zonedTimeToUtc } from 'date-fns-tz';
 
 interface MonthYear {
   orgId: string;
@@ -69,4 +71,99 @@ export async function getBudgetsOverview({ orgId, month, year }: MonthYear) {
 
 export function getBurnRate({ income, expense }: { income: number; expense: number }) {
   return expense / Math.max(income, 1);
+}
+
+export async function getMonthlySeries({
+  orgId,
+  monthsBack = 12,
+}: {
+  orgId: string;
+  monthsBack?: number;
+}) {
+  const tz = 'Asia/Jakarta';
+  const now = utcToZonedTime(new Date(), tz);
+  const currentStart = startOfMonth(now);
+  const months: Date[] = [];
+  for (let i = monthsBack - 1; i >= 0; i--) {
+    months.push(subMonths(currentStart, i));
+  }
+  const map = new Map<string, { income: number; expense: number }>();
+  months.forEach((d) => {
+    map.set(`${d.getFullYear()}-${d.getMonth()}`, { income: 0, expense: 0 });
+  });
+  const startUtc = zonedTimeToUtc(months[0], tz);
+  const endUtc = zonedTimeToUtc(addMonths(currentStart, 1), tz);
+  const txs = await prisma.transaction.findMany({
+    where: { orgId, occurredAt: { gte: startUtc, lt: endUtc } },
+    select: { occurredAt: true, amount: true },
+  });
+  for (const tx of txs) {
+    const local = utcToZonedTime(tx.occurredAt, tz);
+    const key = `${local.getFullYear()}-${local.getMonth()}`;
+    const rec = map.get(key);
+    if (!rec) continue;
+    if (tx.amount > 0) rec.income += tx.amount;
+    else rec.expense += Math.abs(tx.amount);
+  }
+  const series = months.map((d) => {
+    const rec = map.get(`${d.getFullYear()}-${d.getMonth()}`)!;
+    const income = rec.income;
+    const expense = rec.expense;
+    return {
+      y: d.getFullYear(),
+      m: d.getMonth() + 1,
+      income,
+      expense,
+      net: income - expense,
+    };
+  });
+  return series;
+}
+
+export async function getCategoryBreakdown({
+  orgId,
+  month,
+  year,
+}: {
+  orgId: string;
+  month: number;
+  year: number;
+}) {
+  const tz = 'Asia/Jakarta';
+  const start = zonedTimeToUtc(new Date(year, month - 1, 1), tz);
+  const end = zonedTimeToUtc(addMonths(new Date(year, month - 1, 1), 1), tz);
+  const groups: { categoryId: string; _sum: { amount: number | null } }[] =
+    await prisma.transaction.groupBy({
+      by: ['categoryId'],
+      where: { orgId, occurredAt: { gte: start, lt: end }, amount: { lt: 0 } },
+      _sum: { amount: true },
+    });
+  const categoryIds = groups.map((g) => g.categoryId).filter(Boolean) as string[];
+  const categories = await prisma.category.findMany({
+    where: { id: { in: categoryIds } },
+  });
+  const nameMap = new Map<string, string>(categories.map((c: any) => [c.id, c.name]));
+  return groups
+    .map((g) => ({
+      categoryId: g.categoryId,
+      categoryName: nameMap.get(g.categoryId) || 'Unknown',
+      total: Math.abs(g._sum.amount || 0),
+    }))
+    .sort((a, b) => b.total - a.total);
+}
+
+export async function getAdviceRecent({
+  orgId,
+  userId,
+  limit = 5,
+}: {
+  orgId: string;
+  userId: string;
+  limit?: number;
+}) {
+  return prisma.advice.findMany({
+    where: { orgId, userId },
+    orderBy: { createdAt: 'desc' },
+    take: limit,
+  });
 }

--- a/lib/rateLimit.test.ts
+++ b/lib/rateLimit.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from 'vitest';
+import { limit, resetAll } from './rateLimit';
+
+describe('rateLimit', () => {
+  it('blocks after exceeding limit', async () => {
+    await limit({ key: 'a', limit: 2, windowMs: 1000 });
+    await limit({ key: 'a', limit: 2, windowMs: 1000 });
+    await expect(limit({ key: 'a', limit: 2, windowMs: 1000 })).rejects.toThrow();
+    await resetAll();
+  });
+
+  it('resets after window', async () => {
+    vi.useFakeTimers();
+    await limit({ key: 'b', limit: 1, windowMs: 1000 });
+    vi.advanceTimersByTime(1000);
+    await expect(limit({ key: 'b', limit: 1, windowMs: 1000 })).resolves.toBeTruthy();
+    vi.useRealTimers();
+    await resetAll();
+  });
+});

--- a/lib/rateLimit.ts
+++ b/lib/rateLimit.ts
@@ -1,0 +1,29 @@
+import { memoryStore, RateLimitStore } from './rateLimitStore';
+
+const store: RateLimitStore = memoryStore;
+
+export async function limit({
+  key,
+  limit,
+  windowMs,
+}: {
+  key: string;
+  limit: number;
+  windowMs: number;
+}) {
+  const now = Date.now();
+  let rec = await store.get(key);
+  if (!rec || rec.resetAt <= now) {
+    rec = { count: 0, resetAt: now + windowMs };
+  }
+  rec.count += 1;
+  await store.set(key, rec);
+  if (rec.count > limit) {
+    throw new Response('Too many requests', { status: 429 });
+  }
+  return { remaining: Math.max(0, limit - rec.count), resetAt: rec.resetAt };
+}
+
+export async function resetAll() {
+  await store.clear();
+}

--- a/lib/rateLimitStore.ts
+++ b/lib/rateLimitStore.ts
@@ -1,0 +1,25 @@
+export interface RateLimitRecord {
+  count: number;
+  resetAt: number;
+}
+
+export interface RateLimitStore {
+  get(key: string): Promise<RateLimitRecord | undefined>;
+  set(key: string, record: RateLimitRecord): Promise<void>;
+  clear(): Promise<void>;
+}
+
+class MemoryStore implements RateLimitStore {
+  private store = new Map<string, RateLimitRecord>();
+  async get(key: string) {
+    return this.store.get(key);
+  }
+  async set(key: string, record: RateLimitRecord) {
+    this.store.set(key, record);
+  }
+  async clear() {
+    this.store.clear();
+  }
+}
+
+export const memoryStore = new MemoryStore();

--- a/messages/en.json
+++ b/messages/en.json
@@ -41,5 +41,13 @@
   "Delete": "Delete",
   "Search": "Search",
   "All Categories": "All Categories",
-  "Filter": "Filter"
+  "Filter": "Filter",
+  "Reports": "Reports",
+  "Cashflow (12 bulan)": "Cashflow (12 months)",
+  "Kategori Pengeluaran (Bulan Ini)": "Spending by Category (This Month)",
+  "Rekomendasi Terbaru": "Recent Advice",
+  "Tidak ada data": "No data",
+  "Coba lagi": "Try again",
+  "Sumber data tidak tersedia": "Data source unavailable",
+  "Batas permintaan tercapai": "Rate limit exceeded"
 }

--- a/messages/id.json
+++ b/messages/id.json
@@ -41,5 +41,13 @@
   "Delete": "Hapus",
   "Search": "Cari",
   "All Categories": "Semua Kategori",
-  "Filter": "Saring"
+  "Filter": "Saring",
+  "Reports": "Laporan",
+  "Cashflow (12 bulan)": "Arus Kas (12 bulan)",
+  "Kategori Pengeluaran (Bulan Ini)": "Pengeluaran per Kategori (Bulan Ini)",
+  "Rekomendasi Terbaru": "Rekomendasi Terbaru",
+  "Tidak ada data": "Tidak ada data",
+  "Coba lagi": "Coba lagi",
+  "Sumber data tidak tersedia": "Sumber data tidak tersedia",
+  "Batas permintaan tercapai": "Batas permintaan tercapai"
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "openai": "^5.12.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "recharts": "^2.10.4",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.3.1(react@18.3.1)
+      recharts:
+        specifier: ^2.10.4
+        version: 2.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       zod:
         specifier: ^3.22.4
         version: 3.25.76
@@ -590,6 +593,33 @@ packages:
   '@types/bcryptjs@2.4.6':
     resolution: {integrity: sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==}
 
+  '@types/d3-array@3.2.1':
+    resolution: {integrity: sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.7':
+    resolution: {integrity: sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -999,6 +1029,10 @@ packages:
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1045,6 +1079,50 @@ packages:
   csv-parse@6.1.0:
     resolution: {integrity: sha512-CEE+jwpgLn+MmtCpVcPtiCZpVtB6Z2OKPTr34pycYYoL7sxdOkXDdQ4lRiw6ioC0q6BLqhc6cKweCVvral8yhw==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.0:
+    resolution: {integrity: sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
@@ -1085,6 +1163,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
@@ -1129,6 +1210,9 @@ packages:
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
+
+  dom-helpers@5.2.1:
+    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -1329,6 +1413,9 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
@@ -1341,6 +1428,10 @@ packages:
 
   fast-diff@1.3.0:
     resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
+
+  fast-equals@5.2.2:
+    resolution: {integrity: sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==}
+    engines: {node: '>=6.0.0'}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -1539,6 +1630,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   intl-messageformat@10.7.16:
     resolution: {integrity: sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==}
@@ -1761,6 +1856,9 @@ packages:
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
@@ -2179,6 +2277,18 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
+  react-smooth@4.0.4:
+    resolution: {integrity: sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  react-transition-group@4.4.5:
+    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
+
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
@@ -2189,6 +2299,16 @@ packages:
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
+
+  recharts-scale@0.4.5:
+    resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
+
+  recharts@2.15.4:
+    resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -2445,6 +2565,9 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -2562,6 +2685,9 @@ packages:
 
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+
+  victory-vendor@36.9.2:
+    resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
 
   vite-node@1.6.1:
     resolution: {integrity: sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==}
@@ -3058,6 +3184,30 @@ snapshots:
 
   '@types/bcryptjs@2.4.6': {}
 
+  '@types/d3-array@3.2.1': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.7':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
@@ -3497,6 +3647,8 @@ snapshots:
 
   client-only@0.0.1: {}
 
+  clsx@2.1.1: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -3528,6 +3680,44 @@ snapshots:
   csstype@3.1.3: {}
 
   csv-parse@6.1.0: {}
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.0: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.0
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
 
   damerau-levenshtein@1.0.8: {}
 
@@ -3564,6 +3754,8 @@ snapshots:
   debug@4.4.1:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   decimal.js@10.6.0: {}
 
@@ -3604,6 +3796,11 @@ snapshots:
   doctrine@3.0.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-helpers@5.2.1:
+    dependencies:
+      '@babel/runtime': 7.28.3
+      csstype: 3.1.3
 
   dunder-proto@1.0.1:
     dependencies:
@@ -3967,6 +4164,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventemitter3@4.0.7: {}
+
   eventemitter3@5.0.1: {}
 
   execa@8.0.1:
@@ -3984,6 +4183,8 @@ snapshots:
   fast-deep-equal@3.1.3: {}
 
   fast-diff@1.3.0: {}
+
+  fast-equals@5.2.2: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -4194,6 +4395,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  internmap@2.0.3: {}
 
   intl-messageformat@10.7.16:
     dependencies:
@@ -4436,6 +4639,8 @@ snapshots:
       p-locate: 5.0.0
 
   lodash.merge@4.6.2: {}
+
+  lodash@4.17.21: {}
 
   log-update@6.1.0:
     dependencies:
@@ -4825,6 +5030,23 @@ snapshots:
 
   react-is@18.3.1: {}
 
+  react-smooth@4.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      fast-equals: 5.2.2
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+
+  react-transition-group@4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.28.3
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
@@ -4836,6 +5058,23 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
+
+  recharts-scale@0.4.5:
+    dependencies:
+      decimal.js-light: 2.5.1
+
+  recharts@2.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      clsx: 2.1.1
+      eventemitter3: 4.0.7
+      lodash: 4.17.21
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-is: 18.3.1
+      react-smooth: 4.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      recharts-scale: 0.4.5
+      tiny-invariant: 1.3.3
+      victory-vendor: 36.9.2
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -5180,6 +5419,8 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tiny-invariant@1.3.3: {}
+
   tinybench@2.9.0: {}
 
   tinyglobby@0.2.14:
@@ -5327,6 +5568,23 @@ snapshots:
   uuid@8.3.2: {}
 
   v8-compile-cache-lib@3.0.1: {}
+
+  victory-vendor@36.9.2:
+    dependencies:
+      '@types/d3-array': 3.2.1
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.7
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   vite-node@1.6.1(@types/node@20.19.11):
     dependencies:


### PR DESCRIPTION
## Summary
- add analytics helpers and reports page with charts & advice list
- introduce in-memory rate limiting and guard auth/coach actions
- document reports and rate limiting setup in README

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build` *(fails: Cannot find module '.prisma/client/default')*


------
https://chatgpt.com/codex/tasks/task_e_689f717065088327adf6f2d27cfa2e4b