### PR TITLE
feat: add English i18n and locale formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,17 @@ AI tidak memiliki akses langsung ke basis data. Seluruh data diambil melalui _to
 Halaman `/reports` menampilkan grafik arus kas 12 bulan terakhir dan pie pengeluaran per kategori bulan berjalan. Data diolah melalui helper pada `lib/analytics.ts` yang menscope `orgId` dan menggunakan zona waktu `Asia/Jakarta`.
 
 Autentikasi dan aksi chat dilindungi oleh util rate limit (`lib/rateLimit.ts`) dengan batas default 10 permintaan/10 menit untuk login dan 1 pesan/2 detik untuk coach. Middleware tenant memastikan semua operasi basis data terscope ke organisasi aktif.
+
+## Internationalization
+
+AngsFlow menggunakan [next-intl](https://next-intl-docs.vercel.app/) untuk menerjemahkan UI.
+Saat ini mendukung locale **id** dan **en**.
+Preferensi bahasa disimpan di `localStorage` melalui tombol toggle di navbar.
+
+### Menambah Locale Baru
+
+1. Tambah file `messages/<locale>.json` berisi terjemahan.
+2. Masukkan kode locale baru pada `locales` di `i18n.ts`.
+3. Sediakan toggle/opsi pilihan bahasa jika diperlukan.
+
+Jika suatu kunci terjemahan tidak ditemukan, aplikasi akan menggunakan nilai dari locale default.

--- a/app/[locale]/budgets/page.tsx
+++ b/app/[locale]/budgets/page.tsx
@@ -3,11 +3,12 @@ import { requireUser } from '@/lib/auth/requireUser';
 import { requireOrg } from '@/lib/auth/requireOrg';
 import { prisma } from '@/lib/prisma';
 import { getBudgetProgress, createBudget, updateBudget, deleteBudget } from '@/app/budgets/actions';
-import { formatCurrencyIDR } from '@/lib/formatCurrencyIDR';
-import { getTranslations } from 'next-intl/server';
+import { formatCurrency } from '@/lib/format';
+import { getTranslations, getLocale } from 'next-intl/server';
 
 export default async function BudgetsPage() {
   const t = await getTranslations();
+  const locale = await getLocale();
   await requireUser();
   const orgId = await requireOrg();
   const now = new Date();
@@ -35,9 +36,9 @@ export default async function BudgetsPage() {
           {progress.map((p: any) => (
             <tr key={p.categoryId} className="border-b">
               <td className="p-1">{p.categoryName}</td>
-              <td className="p-1 text-right">{formatCurrencyIDR(p.limit)}</td>
-              <td className="p-1 text-right">{formatCurrencyIDR(p.spent)}</td>
-              <td className="p-1 text-right">{formatCurrencyIDR(p.remaining)}</td>
+              <td className="p-1 text-right">{formatCurrency(p.limit, locale)}</td>
+              <td className="p-1 text-right">{formatCurrency(p.spent, locale)}</td>
+              <td className="p-1 text-right">{formatCurrency(p.remaining, locale)}</td>
               <td className="p-1">
                 {p.budgetId && (
                   <form action={updateBudget as any} className="flex gap-1 mb-1">

--- a/app/[locale]/dashboard/page.tsx
+++ b/app/[locale]/dashboard/page.tsx
@@ -8,11 +8,12 @@ import {
   getBurnRate,
 } from '@/lib/analytics';
 import { prisma } from '@/lib/prisma';
-import { formatCurrencyIDR } from '@/lib/formatCurrencyIDR';
-import { getTranslations } from 'next-intl/server';
+import { formatCurrency } from '@/lib/format';
+import { getTranslations, getLocale } from 'next-intl/server';
 
 export default async function DashboardPage() {
   const t = await getTranslations();
+  const locale = await getLocale();
   await requireUser();
   const orgId = await requireOrg();
   const now = new Date();
@@ -32,13 +33,13 @@ export default async function DashboardPage() {
       <h1 className="text-xl">{t('Dashboard')}</h1>
       <div>
         <p>
-          {t('Income')}: {formatCurrencyIDR(cash.income)}
+          {t('Income')}: {formatCurrency(cash.income, locale)}
         </p>
         <p>
-          {t('Expense')}: {formatCurrencyIDR(cash.expense)}
+          {t('Expense')}: {formatCurrency(cash.expense, locale)}
         </p>
         <p>
-          {t('Net')}: {formatCurrencyIDR(cash.net)}
+          {t('Net')}: {formatCurrency(cash.net, locale)}
         </p>
         <p>
           {t('Burn Rate')}: {(burn * 100).toFixed(0)}%
@@ -46,13 +47,13 @@ export default async function DashboardPage() {
       </div>
       <div>
         <p>
-          {t('Total Limit')}: {formatCurrencyIDR(overview.totalLimit)}
+          {t('Total Limit')}: {formatCurrency(overview.totalLimit, locale)}
         </p>
         <p>
-          {t('Total Spent')}: {formatCurrencyIDR(overview.totalSpent)}
+          {t('Total Spent')}: {formatCurrency(overview.totalSpent, locale)}
         </p>
         <p>
-          {t('Remaining')}: {formatCurrencyIDR(overview.totalRemaining)}
+          {t('Remaining')}: {formatCurrency(overview.totalRemaining, locale)}
         </p>
       </div>
       <div>
@@ -60,7 +61,7 @@ export default async function DashboardPage() {
         <ul>
           {top.map((s: any) => (
             <li key={s.categoryId}>
-              {s.categoryName}: {formatCurrencyIDR(s.spent)}
+              {s.categoryName}: {formatCurrency(s.spent, locale)}
             </li>
           ))}
         </ul>
@@ -70,7 +71,7 @@ export default async function DashboardPage() {
         <ul>
           {goals.map((g: any) => (
             <li key={g.id}>
-              {g.name}: {formatCurrencyIDR(g.savedAmt)} / {formatCurrencyIDR(g.targetAmt)}
+              {g.name}: {formatCurrency(g.savedAmt, locale)} / {formatCurrency(g.targetAmt, locale)}
             </li>
           ))}
         </ul>

--- a/app/[locale]/error.tsx
+++ b/app/[locale]/error.tsx
@@ -15,7 +15,7 @@ export default function Error({ error, reset }: { error: Error; reset: () => voi
         {t('Coba lagi')}
       </button>
       <a className="underline" href="https://github.com/angsflow/angsflow/issues" target="_blank">
-        Report issue
+        {t('Report issue')}
       </a>
     </div>
   );

--- a/app/[locale]/goals/Projection.tsx
+++ b/app/[locale]/goals/Projection.tsx
@@ -1,7 +1,8 @@
 'use client';
 import { useState, useTransition } from 'react';
 import { projectGoal } from '@/app/goals/actions';
-import { useTranslations } from 'next-intl';
+import { formatDate } from '@/lib/format';
+import { useLocale, useTranslations } from 'next-intl';
 
 type ProjectionResult =
   | { status: 'achieved' | 'unreachable' }
@@ -9,6 +10,7 @@ type ProjectionResult =
 
 export default function Projection({ goalId }: { goalId: string }) {
   const t = useTranslations();
+  const locale = useLocale();
   const [monthly, setMonthly] = useState(0);
   const [result, setResult] = useState<ProjectionResult | null>(null);
   const [isPending, startTransition] = useTransition();
@@ -42,7 +44,7 @@ export default function Projection({ goalId }: { goalId: string }) {
           </p>
         ) : (
           <p className="text-sm mt-1">
-            {t('ETA')}: {result.monthsNeeded}m -{result.etaDate.toISOString().slice(0, 10)}
+            {t('ETA')}: {result.monthsNeeded}m - {formatDate(result.etaDate, locale)}
           </p>
         ))}
     </div>

--- a/app/[locale]/goals/page.tsx
+++ b/app/[locale]/goals/page.tsx
@@ -3,12 +3,13 @@ import { requireUser } from '@/lib/auth/requireUser';
 import { requireOrg } from '@/lib/auth/requireOrg';
 import { prisma } from '@/lib/prisma';
 import { createGoal, updateGoal, deleteGoal } from '@/app/goals/actions';
-import { formatCurrencyIDR } from '@/lib/formatCurrencyIDR';
-import { getTranslations } from 'next-intl/server';
+import { formatCurrency } from '@/lib/format';
+import { getTranslations, getLocale } from 'next-intl/server';
 import Projection from './Projection';
 
 export default async function GoalsPage() {
   const t = await getTranslations();
+  const locale = await getLocale();
   await requireUser();
   const orgId = await requireOrg();
   const goals = await prisma.goal.findMany({ where: { orgId }, orderBy: { priority: 'asc' } });
@@ -20,7 +21,7 @@ export default async function GoalsPage() {
           <div key={g.id} className="border p-2">
             <h3 className="font-semibold">{g.name}</h3>
             <p>
-              {formatCurrencyIDR(g.savedAmt)} / {formatCurrencyIDR(g.targetAmt)}
+              {formatCurrency(g.savedAmt, locale)} / {formatCurrency(g.targetAmt, locale)}
             </p>
             <Projection goalId={g.id} />
             <form action={updateGoal as any} className="mt-2 flex gap-1">

--- a/app/[locale]/login/page.tsx
+++ b/app/[locale]/login/page.tsx
@@ -27,14 +27,14 @@ export default function LoginPage() {
         type="email"
         value={email}
         onChange={(e) => setEmail(e.target.value)}
-        placeholder="email"
+        placeholder={t('Email')}
         className="border p-2"
       />
       <input
         type="password"
         value={password}
         onChange={(e) => setPassword(e.target.value)}
-        placeholder="password"
+        placeholder={t('Password')}
         className="border p-2"
       />
       <button type="submit" className="bg-blue-500 text-white p-2">

--- a/components/LangToggle.tsx
+++ b/components/LangToggle.tsx
@@ -1,12 +1,32 @@
 'use client';
+import { useEffect } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 
 export default function LangToggle() {
   const pathname = usePathname();
   const router = useRouter();
+  const t = useTranslations();
   const segments = pathname.split('/');
   const locale = segments[1];
   const other = locale === 'id' ? 'en' : 'id';
   const newPath = ['/', other, ...segments.slice(2)].join('/');
-  return <button onClick={() => router.push(newPath)}>{other.toUpperCase()}</button>;
+
+  useEffect(() => {
+    const saved = localStorage.getItem('locale');
+    if (saved && saved !== locale) {
+      router.replace(['/', saved, ...segments.slice(2)].join('/'));
+    }
+  }, [locale, router, segments]);
+
+  function toggle() {
+    localStorage.setItem('locale', other);
+    router.push(newPath);
+  }
+
+  return (
+    <button aria-label={t('Change Language')} onClick={toggle}>
+      {other === 'id' ? '🇮🇩 ID' : '🇺🇸 EN'}
+    </button>
+  );
 }

--- a/components/transactions/TransactionsTable.tsx
+++ b/components/transactions/TransactionsTable.tsx
@@ -2,9 +2,8 @@
 import { useTransition } from 'react';
 import { deleteTransaction } from '@/app/transactions/actions';
 import CategorySelect from '../CategorySelect';
-import { formatDate } from '@/lib/date';
-import { formatCurrencyIDR } from '@/lib/formatCurrencyIDR';
-import { useTranslations } from 'next-intl';
+import { formatDate, formatCurrency } from '@/lib/format';
+import { useLocale, useTranslations } from 'next-intl';
 
 interface Tx {
   id: string;
@@ -28,6 +27,7 @@ export default function TransactionsTable({
   categories: Category[];
 }) {
   const t = useTranslations();
+  const locale = useLocale();
   const [isPending, startTransition] = useTransition();
 
   return (
@@ -44,12 +44,12 @@ export default function TransactionsTable({
       <tbody>
         {transactions.map((tx) => (
           <tr key={tx.id} className="border-t">
-            <td className="p-1">{formatDate(tx.occurredAt, 'yyyy-MM-dd')}</td>
+            <td className="p-1">{formatDate(tx.occurredAt, locale)}</td>
             <td className="p-1">{tx.description}</td>
             <td className="p-1">
               <CategorySelect txId={tx.id} value={tx.categoryId || null} options={categories} />
             </td>
-            <td className="p-1 text-right">{formatCurrencyIDR(tx.amount / 100)}</td>
+            <td className="p-1 text-right">{formatCurrency(tx.amount / 100, locale)}</td>
             <td className="p-1 text-center">
               <button
                 className="text-red-600"

--- a/lib/date.ts
+++ b/lib/date.ts
@@ -1,8 +1,0 @@
-import { format, utcToZonedTime } from 'date-fns-tz';
-
-const TZ = process.env.NEXT_PUBLIC_DEFAULT_TZ || 'Asia/Jakarta';
-
-export function formatDate(date: Date | string, fmt: string) {
-  const zoned = utcToZonedTime(date, TZ);
-  return format(zoned, fmt, { timeZone: TZ });
-}

--- a/lib/format.test.ts
+++ b/lib/format.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'vitest';
+import { formatCurrency, formatDate } from './format';
+
+describe('format helpers', () => {
+  test('formatCurrency respects locale and currency', () => {
+    expect(formatCurrency(1234.56, 'en', 'USD')).toBe('$1,234.56');
+    expect(formatCurrency(1234.56, 'id', 'IDR')).toBe('Rp 1.234,56');
+  });
+
+  test('formatDate respects locale', () => {
+    const d = new Date(Date.UTC(2024, 0, 15));
+    expect(formatDate(d, 'en', { year: 'numeric', month: 'long', day: 'numeric' })).toBe(
+      'January 15, 2024',
+    );
+    expect(formatDate(d, 'id', { year: 'numeric', month: 'long', day: 'numeric' })).toBe(
+      '15 Januari 2024',
+    );
+  });
+});

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -1,0 +1,15 @@
+const DEFAULT_CURRENCY = process.env.NEXT_PUBLIC_DEFAULT_CURRENCY || 'IDR';
+const TZ = process.env.NEXT_PUBLIC_DEFAULT_TZ || 'Asia/Jakarta';
+
+export function formatCurrency(value: number, locale: string, currency: string = DEFAULT_CURRENCY) {
+  return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(value);
+}
+
+export function formatDate(
+  date: Date | string,
+  locale: string,
+  options?: Intl.DateTimeFormatOptions,
+) {
+  const d = typeof date === 'string' ? new Date(date) : date;
+  return new Intl.DateTimeFormat(locale, { timeZone: TZ, ...options }).format(d);
+}

--- a/lib/formatCurrencyIDR.ts
+++ b/lib/formatCurrencyIDR.ts
@@ -1,6 +1,0 @@
-export function formatCurrencyIDR(value: number) {
-  return new Intl.NumberFormat('id-ID', {
-    style: 'currency',
-    currency: 'IDR',
-  }).format(value);
-}

--- a/messages/en.json
+++ b/messages/en.json
@@ -49,5 +49,9 @@
   "Tidak ada data": "No data",
   "Coba lagi": "Try again",
   "Sumber data tidak tersedia": "Data source unavailable",
-  "Batas permintaan tercapai": "Rate limit exceeded"
+  "Batas permintaan tercapai": "Rate limit exceeded",
+  "Email": "Email",
+  "Password": "Password",
+  "Change Language": "Change language",
+  "Report issue": "Report issue"
 }

--- a/messages/id.json
+++ b/messages/id.json
@@ -49,5 +49,9 @@
   "Tidak ada data": "Tidak ada data",
   "Coba lagi": "Coba lagi",
   "Sumber data tidak tersedia": "Sumber data tidak tersedia",
-  "Batas permintaan tercapai": "Batas permintaan tercapai"
+  "Batas permintaan tercapai": "Batas permintaan tercapai",
+  "Email": "Email",
+  "Password": "Kata sandi",
+  "Change Language": "Ganti bahasa",
+  "Report issue": "Laporkan masalah"
 }

--- a/messages/translation.test.ts
+++ b/messages/translation.test.ts
@@ -1,0 +1,11 @@
+import { test, expect } from 'vitest';
+import { createTranslator } from 'next-intl';
+import en from './en.json';
+import id from './id.json';
+
+test('translations differ by locale', () => {
+  const tEn = createTranslator({ locale: 'en', messages: en });
+  const tId = createTranslator({ locale: 'id', messages: id });
+  expect(tEn('Login')).toMatchInlineSnapshot('"Login"');
+  expect(tId('Login')).toMatchInlineSnapshot('"Masuk"');
+});


### PR DESCRIPTION
## Summary
- add English translation strings and language toggle with persistence
- introduce locale-aware currency and date format utilities
- document internationalization support

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build` *(fails: Cannot find module '.prisma/client/default')*


------
https://chatgpt.com/codex/tasks/task_e_689f7560aa908327b3b4137bcb40b5c4